### PR TITLE
cleaned up client side and fix response length

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -30,14 +30,14 @@ struct	Response
 		std::vector<std::string> 			m_headers;
 		bool								m_if_body;
 		std::string							m_body;
-		bool								m_metadata_parsed;
-		bool								m_done;
 		int									m_error;
 };
 
 class	Client
 {
 	public:
+		typedef	Request		t_request_data;
+		typedef	Response	t_response_data;
 		friend class Server;
 		friend class RequestParser;
 		friend class RequestHandler;
@@ -46,19 +46,14 @@ class	Client
 		Client(int socket);
 		Client();
 		bool	fullMetaData();
-
 	private:
-
 		std::string							m_request_str;
-		VirtualServer						*m_v_server;
+		std::string							m_response_str;
+		t_request_data 						m_request_data;
+		t_response_data						m_response_data;
 		int									m_socket;
-		bool 								m_received;
-		bool 								m_treated;
 		struct	sockaddr_storage 			m_sockaddr;
 		socklen_t							m_addrlen;
-		Request								m_request_data;
-		Response							m_reponse_data;
-		std::string							m_response_str;
 };
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -29,9 +29,9 @@ class	Server
 		void	run();
 		void	init();
 		void	close();
-		int		receive(int socket);
+		int		receive(t_client *c);
 		void	respond(int client_socket);
-		t_client *accept(int v_server_socket); // looks for listeners based on the socket, if found accepts it, if not just returns
+		void	accept(int v_server_socket);
 		void	addClient();
 		void	connectVirtualServer(t_v_server &v_server);
 		void	removeClient(int client_socket);

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -3,34 +3,49 @@
 #include "Error.hpp"
 
 Request::Request()
-	: m_method(-1), m_path(""), m_protocol(-1), m_content_length(0), m_headers(0), m_if_body(false), m_body(""), m_done(false) 
+	: m_method(-1),
+	m_path(""),
+	m_protocol(-1),
+	m_content_length(0),
+	m_headers(0),
+	m_if_body(false),
+	m_body(""),
+	m_metadata_parsed(false),
+	m_done(false),
+	m_error(0)
 {
 	for (int i = 0; i < 18; ++i)
 		m_headers.push_back("");
 }
 
 Response::Response()
-	: m_method(-1), m_path(""), m_protocol(-1), m_content_length(0), m_headers(0), m_if_body(false), m_body(""), m_done(false) 
+	: m_method(-1),
+	m_path(""),
+	m_protocol(-1),
+	m_content_length(0),
+	m_headers(0),
+	m_if_body(false),
+	m_body(""),
+	m_error(0)
 {
 	for (int i = 0; i < 18; ++i)
 		m_headers.push_back("");
 }
 
 Client::Client() 
-	: m_request_str(""), m_v_server(0), m_socket(-1), m_received(false), m_treated(false), m_sockaddr(), m_addrlen(sizeof(m_sockaddr))
+	: m_request_str(""),
+	m_response_str(""),
+	m_request_data(),
+	m_response_data(),
+	m_socket(-1),
+	m_sockaddr(),
+	m_addrlen(sizeof(m_sockaddr))
 {
 }
 
 bool	Client::fullMetaData() {
 	return (!this->m_request_str.empty()
 			&& this->m_request_str.find("\r\n\r\n") != std::string::npos);
-}
-
-
-Client::Client(int socket) 
-	: m_request_str(""), m_v_server(0), m_socket(socket), m_received(false), m_sockaddr(), m_addrlen(sizeof(m_sockaddr))
-{
-
 }
 
 void	Server::removeClient(int client_socket) {

--- a/srcs/ServerAccept.cpp
+++ b/srcs/ServerAccept.cpp
@@ -5,12 +5,12 @@
 #include <string.h>
 #include <fcntl.h>
 
-Server::t_client *Server::accept(int v_server_socket) {
+void	Server::accept(int v_server_socket) {
 	t_client	c;
 
 	if ((c.m_socket = ::accept(v_server_socket, reinterpret_cast<struct sockaddr *>(&c.m_sockaddr), &c.m_addrlen)) == -1) {
 		std::cout<<"accept: "<<strerror(errno)<<std::endl;
-		return 0; //can throw WOULDBLOCK
+		return ; //can throw WOULDBLOCK
 	}
 	if (fcntl(c.m_socket, F_SETFL, O_NONBLOCK)  == -1)
 		throw(serverError("fcntl: ", strerror(errno)));
@@ -19,5 +19,4 @@ Server::t_client *Server::accept(int v_server_socket) {
 	FD_SET(c.m_socket, &this->m_read_all);
 	if (c.m_socket > this->m_range_fd)
 		this->m_range_fd = c.m_socket;
-	return &this->m_client_map[c.m_socket];
 }

--- a/srcs/ServerInit.cpp
+++ b/srcs/ServerInit.cpp
@@ -13,6 +13,7 @@ void	Server::init(){
 	FD_ZERO(&this->m_read_all);
 	FD_ZERO(&this->m_write_fd);
 	FD_ZERO(&this->m_read_fd);
+	this->m_range_fd = 0;
 	for (t_v_server_map::iterator it = this->m_v_server_map.begin(); 
 			it != this->m_v_server_map.end(); ++it) {
 		it->second[0].init(); // start default virtual server
@@ -24,8 +25,6 @@ void	Server::init(){
 			it->second[server_block].m_sockaddr = it->second[0].m_sockaddr;
 		}
 		std::cout<<"v_server port "<<it->first<<" listens on socket "<<it->second[0].m_socket<<std::endl;
-		std::cout<<it->second[0].m_sockaddr.sin_addr.s_addr<<std::endl;
-		std::cout<<it->second[0].m_sockaddr.sin_port<<std::endl;
 	}
 }
 

--- a/srcs/ServerReceive.cpp
+++ b/srcs/ServerReceive.cpp
@@ -16,25 +16,22 @@
 #include <fcntl.h>
 #include "Error.hpp"
 
-
-int	Server::receive(int client_socket) {
+int	Server::receive(t_client *c) {
 	char buf[1000]; // can have buf elsewhere
-
 	memset(buf, 0, sizeof(buf));//fill
-	t_client *c = this->getClient(client_socket);
 	if (!c)
 		throw(serverError("getClient ", "client not registered"));
-	int	nbytes = recv(client_socket, buf, sizeof(buf), 0);
+	int	nbytes = recv(c->m_socket, buf, sizeof(buf), 0);
 	const char *to_append = buf;
 	c->m_request_str.append(to_append);
 	if (nbytes <= 0){ // should we handle closing a connection in the ServerRun loop
 		if (nbytes == 0)
-			std::cout<<"closing connection "<<client_socket<<std::endl; //log
+			std::cout<<"closing connection "<<c->m_socket<<std::endl; //log
 		else
 			std::cout<<"recv: "<<strerror(errno)<<std::endl; //log
-		::close(client_socket);
-		FD_CLR(client_socket, &this->m_read_all);
-		this->removeClient(client_socket);
+		::close(c->m_socket);
+		FD_CLR(c->m_socket, &this->m_read_all);
+		this->removeClient(c->m_socket);
 	}
 	return nbytes;
 }

--- a/srcs/ServerRespond.cpp
+++ b/srcs/ServerRespond.cpp
@@ -6,11 +6,10 @@
 void	Server::respond(int client_socket) {
 	std::cout<<"sending response"<<std::endl;
 	t_client *c;
-
 	if ((c = this->getClient(client_socket)) == NULL) {
 		throw serverError("removeClient: ", "trying to remove unexisting client");
 	}
-	 if (send(c->m_socket, c->m_response_str.c_str(), c->m_response_str.size(), 0) == -1)
+	 if (send(c->m_socket, c->m_response_str.c_str(), c->m_response_str.size() + 1, 0) == -1)
 		 std::cout<<"send: "<<strerror(errno)<<std::endl;
 	 FD_CLR(c->m_socket, &this->m_write_all);
 }

--- a/srcs/ServerRun.cpp
+++ b/srcs/ServerRun.cpp
@@ -38,15 +38,15 @@ void	Server::run(){
 				v_server = getVirtualServer(i); //find corresponding v_server
 				std::cout<<"found read connection fd: "<<i<<std::endl;
 				if (v_server)
-					c = this->accept(i);
+					this->accept(i);
 				else
 				{
-					if (this->receive(i) > 0) {
-
+					c = getClient(i);
+					if (this->receive(c) > 0) {
 					 		if (!c->m_request_data.m_metadata_parsed) {
 					 			if (!c->fullMetaData())
 					 				continue ;
-								std::cout<<"received full http request"<<std::endl;
+								std::cout<<"received full metadata"<<std::endl;
 								// if (parse != error)
 								// 	this->handleMetadata(*c); 
 								// 	if error, flag the request as done, and as erroneous, so handle request can generate a error page.
@@ -58,6 +58,7 @@ void	Server::run(){
 							{
 					 			this->m_request_handler.handleRequest(*c);
 								FD_SET(c->m_socket, &this->m_write_all);
+								c->m_request_str.clear();
 							}
 					 		else
 					 			RequestParser::HandleBody(*c);


### PR DESCRIPTION
Init every variable to default value in Client,
set this->range_fd to 0 in Server solves the occasional random fd returned by select.
c->m_response.length() was one byte too short, causing user-agent to not receive eof for some reason and not send eof back, thus not closing the connection.
Solved confusion about value of client pointer in ServerRun.