### PR TITLE
Testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,13 @@ SANITIZE	?=	0
 DEBUG		?=	0
 LOG			?=	0
 LOG_FILE	?=	0
+LEAKS		?= 0
 
 ifeq ($(SANITIZE), 1)
 FLAGS+= -g -fsanitize=address
 endif
+
+
 
 ifeq ($(DEBUG), 1)
 FLAGS+= -g
@@ -69,7 +72,25 @@ define NL
 
 endef
 
-all: $(NAME) config
+leaks_in:
+ifeq ($(LEAKS), 1)
+ifneq ($(SANITIZE), 1)
+ifneq (, $(shell which leaks))
+	patch $(SRC_DIR)/main.cpp leaks_in.diff -R
+endif 
+endif
+endif
+
+leaks_out:
+ifeq ($(LEAKS), 1)
+ifneq ($(SANITIZE), 1)
+ifneq (, $(shell which leaks))
+	patch $(SRC_DIR)/main.cpp leaks_out.diff
+endif 
+endif 
+endif
+
+all: leaks_in $(NAME) config leaks_out
 
 $(NAME): $(OBJ)
 	@$(foreach obj, $?, echo Linking $(notdir $(obj))$(NL))
@@ -89,6 +110,7 @@ clean_config:
 fclean:
 	@$(MAKE) clean clean_config
 	$(RM) $(wildcard $(NAME))
+	$(RM) leaks
 
 re:
 	$(MAKE) fclean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 OS 			:= $(shell uname)
+PHP_PATH 	:= $(shell which php-cgi)
 NAME		:=	webserv
 FLAGS		=	-Wall -Wextra -Werror -std=c++98 -pedantic
 
@@ -100,6 +101,7 @@ config:
 		REPO=$(REPO) \
 		TEST_DIR=$(TEST_DIR) \
 		CGI_TESTER=$(CGI_TESTER) \
+		PHP_PATH=$(PHP_PATH) \
 		./generate_config.pl
 
 .PHONY: all clean fclean re

--- a/TODO.md
+++ b/TODO.md
@@ -7,9 +7,10 @@
 - [x] Implement missing headers
 - [x] Accept-Charset
 - [x] User-Agent
-- [ ] Referer
-- [ ] Retry-After
+- [x] Referer
+- [x] Retry-After
 - [x] Write tests for POST cgi with html forms
+
 - [ ] post really always 200
 
 
@@ -33,4 +34,4 @@ Monday 29-03
 - [x] check how exactly tv influences select()
 - [x] handle put trim upload_store better
 - [x] write some more test for compare python and add to hooks
-- [ ] add PHPCGI variable in Makefile
+- [x] add PHPCGI variable in Makefile

--- a/conf_templates/ft_server.conf
+++ b/conf_templates/ft_server.conf
@@ -9,7 +9,7 @@ server {
         index                   index.html index.htm index.php;
         autoindex               on;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 
     location /phpmyadmin/ {
@@ -17,6 +17,6 @@ server {
         index                   index.html index.htm index.php;
         autoindex               on;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 }

--- a/conf_templates/multi_name.conf
+++ b/conf_templates/multi_name.conf
@@ -10,7 +10,7 @@ server {
         alias 					$WWW/name1/;
         index                   index.html index.htm;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 
 }
@@ -25,7 +25,7 @@ server {
         alias 					$WWW/name2/;
         index                   index.html index.htm;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 }
 
@@ -39,7 +39,7 @@ server {
         alias 					$WWW/name3;
         index                   index.html index.htm;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 }
 
@@ -54,7 +54,7 @@ server {
         alias 					$WWW/name2;
         index                   index.html index.htm;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 }
 
@@ -68,6 +68,6 @@ server {
         alias 					$WWW/name2;
         index                   index.html index.htm;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 }

--- a/conf_templates/nginx_cmp.conf
+++ b/conf_templates/nginx_cmp.conf
@@ -20,7 +20,7 @@ http {
             # auth_basic              "Access to the Webserver";
             # auth_basic_user_file    test_conf/.htpasswd;
 		    # cgi	                    .php;
-		    # cgi_path                /usr/bin/php-cgi;
+		    # cgi_path                $PHP_PATH;
         }
 
         location /put_test/ {
@@ -51,14 +51,14 @@ http {
         #     # auth_basic              "Access to the Webserver";
         #     # auth_basic_user_file    test_conf/.htpasswd;
         #     # cgi	                    .;
-        #     # cgi_path                 /usr/bin/php-cgi;
+        #     # cgi_path                 $PHP_PATH;
         # }
 
         # location /ok {
         #     alias   /usr/share/nginx/yes/html;
         #     index  index.html index.htm;
         #     # cgi	.php;
-        #     # cgi_path  /usr/bin/php-cgi;
+        #     # cgi_path  $PHP_PATH;
         # }
 
 
@@ -80,7 +80,7 @@ http {
         #     alias /usr/share/nginx/other/html;
         #     index  index.html index.htm;
         #     # cgi	.php;
-        #     # cgi_path  /usr/bin/php-cgi;
+        #     # cgi_path  $PHP_PATH;
         # }
     }
 }

--- a/conf_templates/post_test.conf
+++ b/conf_templates/post_test.conf
@@ -12,7 +12,7 @@ server {
         auth_basic              "Access to the Webserver";
         auth_basic_user_file    $PWD/conf/.htpasswd;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
     location /perl {
         alias 					$WWW/cgi-bin/;
@@ -27,6 +27,6 @@ server {
         index                   check_env.php;
         allow_method            GET POST PUT;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 }

--- a/conf_templates/webserv.conf
+++ b/conf_templates/webserv.conf
@@ -17,7 +17,7 @@ server {
         # auth_basic              "Access to the Webserver";
         # auth_basic_user_file    $PWD/conf/.htpasswd;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 
     location /css/ {
@@ -62,7 +62,7 @@ server {
         index                   check_env.php;
         allow_method            GET POST PUT;
 		cgi	.php;
-		cgi_path  /usr/bin/php-cgi;
+		cgi_path  $PHP_PATH;
     }
 
     location /language {

--- a/conf_templates/webserv_cmp.conf
+++ b/conf_templates/webserv_cmp.conf
@@ -14,7 +14,7 @@
 #         # auth_basic              "Access to the Webserver";
 #         # auth_basic_user_file    test_conf/.htpasswd;
 # 		# cgi	                    .php;
-# 		# cgi_path                /usr/bin/php-cgi;
+# 		# cgi_path                $PHP_PATH;
 #     }
 
 #     location /put_test/ {
@@ -45,7 +45,7 @@
 #         # auth_basic              "Access to the Webserver";
 #         # auth_basic_user_file    test_conf/.htpasswd;
 # 		# cgi	                    .php;
-# 		# cgi_path                /usr/bin/php-cgi;
+# 		# cgi_path                $PHP_PATH;
 #     }
 # }
 
@@ -101,14 +101,14 @@ server {
     #     # auth_basic              "Access to the Webserver";
     #     # auth_basic_user_file    test_conf/.htpasswd;
 	# 	# cgi	                    .;
-	# 	# cgi_path                 /usr/bin/php-cgi;
+	# 	# cgi_path                 $PHP_PATH;
     # }
 
     # location /ok {
     #     alias   /usr/share/nginx/yes/html;
     #     index  index.html index.htm;
 	# 	cgi	.php;
-	# 	cgi_path  /usr/bin/php-cgi;
+	# 	cgi_path  $PHP_PATH;
     # }
 
 
@@ -130,7 +130,7 @@ server {
     #     alias /usr/share/nginx/other/html;
     #     index  index.html index.htm;
 	# 	cgi	.php;
-	# 	cgi_path  /usr/bin/php-cgi;
+	# 	cgi_path  $PHP_PATH;
     # }
 
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+full=0
+interactive=0
+
+#when launched as a pre-push hook by git
+# note: won't run 42 tester if FULL_HOOK is not exported in the calling shell
+# export FULL_HOOK=[1-0] INTERACTIVE_HOOK=[1-0] to change that
+
+[[ "$FULL_HOOK" == "1" ]] && full=1
+[[ "$INTERACTIVE_HOOK" == "1" ]] && interactive=1
+
+#when launched from cli
+for arg in "$@"
+do
+	[[ "$arg" == "--full" ]] && full=1
+	[[ "$arg" == "-i" ]] && interactive=1
+done
+
 function clean_exit() {
 	pkill webserv > /dev/null 2>&1
 	make fclean
@@ -21,13 +38,27 @@ function assert() {
 }
 
 trap "clean_exit 1" SIGHUP SIGINT SIGTERM
-remote="$1"
-url="$2"
 
 assert "which python3" "please install python3"
 assert "which php-cgi" "please install php-cgi"
 
 make re config
+
+./webserv ./conf/tester.conf > /dev/null 2>&1 &
+
+sleep 1
+
+if [ $full -eq 1 ]
+then
+	if [ $interactive -eq 1 ]
+	then
+		assert "./tests/ubuntu_tester http://localhost:8080"
+	else
+		echo "" | assert "./tests/ubuntu_tester http://localhost:8080"
+	fi
+fi
+
+pkill webserv > /dev/null 2>&1
 ./webserv ./conf/webserv.conf > /dev/null 2>&1 &
 
 sleep 1

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -2,6 +2,9 @@
 
 full=0
 interactive=0
+leaks=0
+tester="./tests/tester"
+[[ "$(uname)" == "Linux" ]] && tester="./tests/ubuntu_tester"
 
 #when launched as a pre-push hook by git
 # note: won't run 42 tester if FULL_HOOK is not exported in the calling shell
@@ -9,13 +12,16 @@ interactive=0
 
 [[ "$FULL_HOOK" == "1" ]] && full=1
 [[ "$INTERACTIVE_HOOK" == "1" ]] && interactive=1
+[[ "$LEAKS_HOOK" == "1" ]] && leaks=1
 
 #when launched from cli
 for arg in "$@"
 do
 	[[ "$arg" == "--full" ]] && full=1
 	[[ "$arg" == "-i" ]] && interactive=1
+	[[ "$arg" == "--leaks" ]] && leaks=1
 done
+
 
 function clean_exit() {
 	pkill webserv > /dev/null 2>&1
@@ -42,7 +48,7 @@ trap "clean_exit 1" SIGHUP SIGINT SIGTERM
 assert "which python3" "please install python3"
 assert "which php-cgi" "please install php-cgi"
 
-make re config
+make re LEAKS=$leaks config
 
 ./webserv ./conf/tester.conf > /dev/null 2>&1 &
 
@@ -52,9 +58,9 @@ if [ $full -eq 1 ]
 then
 	if [ $interactive -eq 1 ]
 	then
-		assert "./tests/ubuntu_tester http://localhost:8080"
+		assert "$tester http://localhost:8080"
 	else
-		echo "" | assert "./tests/ubuntu_tester http://localhost:8080"
+		echo "" | assert "$tester http://localhost:8080"
 	fi
 fi
 
@@ -78,5 +84,7 @@ pkill webserv > /dev/null 2>&1
 
 sleep 1
 assert "tests/multi_name.sh"
+
+[[ $leaks == 1 ]] && if (ls leaks) then echo "leaks detected"; clean_exit 1; fi
 
 clean_exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,70 +1,51 @@
-#!/bin/sh
+#!/bin/bash
 
-# An example hook script to verify what is about to be pushed.  Called by "git
-# push" after it has checked the remote status, but before anything has been
-# pushed.  If this script exits with a non-zero status nothing will be pushed.
-#
-# This hook is called with the following parameters:
-#
-# $1 -- Name of the remote to which the push is being done
-# $2 -- URL to which the push is being done
-#
-# If pushing without using a named remote those arguments will be equal.
-#
-# Information about the commits which are being pushed is supplied as lines to
-# the standard input in the form:
-#
-#   <local ref> <local oid> <remote ref> <remote oid>
-#
+function clean_exit() {
+	pkill webserv > /dev/null 2>&1
+	make fclean
+	if [ $1 -eq 1 ]
+	then
+		echo "FAILED"
+	 else
+		echo "OK"
+	fi
+	exit $1
+}
 
-trap "pkill webserv > /dev/null 2>&1; make fclean ; exit 1" SIGHUP SIGINT SIGTERM
+function assert() {
+	if !($1)
+	then
+		[[ -n "$2" ]] && echo $2
+		clean_exit 1
+	fi
+}
+
+trap "clean_exit 1" SIGHUP SIGINT SIGTERM
 remote="$1"
 url="$2"
 
+assert "which python3" "please install python3"
+assert "which php-cgi" "please install php-cgi"
+
 make re config
 ./webserv ./conf/webserv.conf > /dev/null 2>&1 &
-sleep 1
-if !(pgrep webserv > /dev/null)
-	then
-		echo "FAILED"
-		exit 1
-fi
-if !(python3 ./tests/test.py);
-then
-	pkill webserv > /dev/null 2>&1
-	echo "FAILED"
-	exit 1
-fi
 
-pkill webserv > /dev/null 2>&1 
-
-./webserv ./conf/webserv_cmp.conf > /dev/null 2>&1 &
 sleep 1
-if !(pgrep webserv > /dev/null)
-	then
-		echo "FAILED"
-		exit 1
-fi
-if !(python3 tests/compare_test/compare_test.py webserv)
-then
-	pkill webserv > /dev/null 2>&1
-	echo "FAILED"
-	exit 1
-fi
+
+assert "pgrep webserv"
+assert "python3 ./tests/test.py"
+
 pkill webserv > /dev/null 2>&1
+./webserv ./conf/webserv_cmp.conf > /dev/null 2>&1 &
 
-
-./webserv ./conf/multi_name.conf > /dev/null 2>&1 &
 sleep 1
-if !(tests/multi_name.sh)
-then
-	pkill webserv > /dev/null 2>&1
-	echo "FAILED"
-	exit 1
-fi
-# ./webserv ./conf/tester.conf
+assert "pgrep webserv"
+assert "python3 tests/compare_test/compare_test.py webserv"
 
-make fclean
+pkill webserv > /dev/null 2>&1
+./webserv ./conf/multi_name.conf > /dev/null 2>&1 &
 
-echo "OK"
-exit 0
+sleep 1
+assert "tests/multi_name.sh"
+
+clean_exit 0

--- a/includes/Cgi.hpp
+++ b/includes/Cgi.hpp
@@ -5,7 +5,7 @@
 # include <string>
 # include "Client.hpp"
 
-# define CGI_ENV_DEFAULT_SIZE 20
+# define CGI_ENV_DEFAULT_SIZE 21
 # define CGI_BUF_SIZE 500000
 
 

--- a/leaks_in.diff
+++ b/leaks_in.diff
@@ -1,0 +1,2 @@
+24d23
+< 	system("leaks -quiet webserv; [[ $? == 1 ]] && touch leaks");

--- a/leaks_out.diff
+++ b/leaks_out.diff
@@ -1,0 +1,2 @@
+24d23
+< 	system("leaks -quiet webserv; [[ $? == 1 ]] && touch leaks");

--- a/srcs/RequestHandler.cpp
+++ b/srcs/RequestHandler.cpp
@@ -625,10 +625,13 @@ std::string		RequestHandler::handlePUT()
 	std::string const & m_file = this->m_request_data->m_file;
 	std::string upload_store = this->m_request_data->m_location->second["upload_store"];
 	size_t	trim = upload_store.find(" ");
+	char buf[PATH_MAX];
+	char *current_dir;
 
 	if (trim != std::string::npos)
 		upload_store.resize(trim);
-	char* current_dir = getcwd(NULL, 0);
+	if ((current_dir = getcwd(buf, PATH_MAX)) == NULL)
+		throw HTTPError("RequestHandler::handlePUT", strerror(errno), 500);
 	if (chdir(upload_store.c_str()))
 		throw HTTPError("RequestHandler::PUT", "Upload store directory doesn't exist", 500);
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -31,7 +31,8 @@ int	main(int ac, char **av) {
 	try
 	{
 		if (signal(SIGPIPE, SIG_IGN) == SIG_ERR
-				|| signal(SIGINT, &sigtermClose) == SIG_ERR)
+				|| signal(SIGINT, &sigtermClose) == SIG_ERR
+				|| signal(SIGTERM, &sigtermClose) == SIG_ERR)
 			throw serverError("main: signal:", strerror(errno));
 
 		char	const *path = ac == 2 ? av[1] : DEFAULT_PATH;

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,9 @@
-import requests
-import  os
-import time
-import logging
+try:
+    import requests, os, time, logging
+except  ImportError:
+    print("Please install the required modules")
+    exit()
+
 
 class bcolors:
     HEADER = '\033[95m'


### PR DESCRIPTION
PHP_PATH variable in configs
getcwd with buff=NULL will use malloc, thus causing a memory leak in handlePut.
Updated CGI array size
better pre-push script that takes arguments or env variables to run the tester interactively or not.